### PR TITLE
Added Same Origin Policy

### DIFF
--- a/docs/specs/runtime/securityanalysis.md
+++ b/docs/specs/runtime/securityanalysis.md
@@ -19,6 +19,10 @@ In the basic threat model, we assume that an attacker can server arbitrary clien
 
 The basic mechanism of our architecture to prevent unauthorized access by client code is sandboxing. Each Hyperty instance running in the system runs in its own sandbox. A sandbox defines a security perimeter for the Hyperty instance, preventing it from reading or writing the memory (or other resources) allocated to other Hyperty instances or by other components in the surrounding environment. An independent sandbox hosts the ProtoStub instance required by local Hyperty instances to communicate with external services. This sandbox will prevent  potentially malicious ProtoSub code from unauthorized access to resources. To communicate outside the sandboxes, the runtime provides well defined interfaces: the Syncer, which is used by the Hyperty instance to communicate with the SPPE, and an API to communicate with the Message Bus. The SPPE and the PEE are responsible for enforcing the policy associated with the Hyperty instance.
 
+Client code is identified by its origin. An origin is a combination of URI scheme, hostname and port number. The origin can be asserted using certificates (e.g. using TLS) thus we only allows client code from secure origin.
+
+Client codes are subject to Same Origin Policy for direct interactions between codes. However this can be relaxed using Cross Origin Resource Sharing (CORS) policy declarations. Client codes from different origin can still communicate without CORS using the Message Bus API. Message exchange must be identified by senders and recipients origin. Subscription to messaging channels (where multiple client codes could publish messages) must be subject to authorization.
+
 Note that, in our architecture, sandboxing is also used to secure the components of the Hyperty Runtime that are implemented in JavaScript, namely the components allocated in the Core Sandbox. The JavaScript engine implements both the client code sandboxes and the Core Sandbox.
 
 #### T2: Policy subversion
@@ -27,7 +31,7 @@ Every Hyperty instance is constrained by a policy. A policy defines a set of rul
 
 #### T3: Threats to client code authenticity
 
-The authenticity of client code -- Hyperty, ProtoStub, or SPPE -- can be compromised if at least one of two events has occurred without being detected before the code is loaded and instantiated into a sandbox: an attacker has modified the original code bytes (e.g., by embedding malware into a Hyperty code), or (ii) has modified the code identity or the manufacturer identity. To prevent such attacks, client code must be digitally signed by its manufacturer. By checking these signatures before instantiating the Hyperty, ProtoStub, or SPPE code on the sandboxes and assuming that the cryptographic primitives are correctly implemented, the Hyperty Runtime can guarantee the integrity and identity of the code.
+The authenticity of client code -- Hyperty, ProtoStub, or SPPE -- can be compromised if at least one of two events has occurred without being detected before the code is loaded and instantiated into a sandbox: an attacker has modified the original code bytes (e.g., by embedding malware into a Hyperty code), or (ii) has modified the code identity. To prevent such attacks, client code's origin must be digitally signed and transmitted over a secure channel. Additionally the client code may be signed by its manufacturer. By checking these signatures before instantiating the Hyperty, ProtoStub, or SPPE code on the sandboxes and assuming that the cryptographic primitives are correctly implemented, the Hyperty Runtime can guarantee the integrity and identity of the code.
 
 #### T4: Denial of service attacks
 


### PR DESCRIPTION
I made the following changes from issue #47

Added:
Client code identity from Origin
Origin asserted by signed secure channel (e.g. TLS)
Same Origin Policy and CORS
Message in Messaging Bus should contains identity from Sender, Recipient
Subscription to Messaging channel in Message Bus is subject to authorization

Modified
Code signature by manufacturer made optional. Replaced by content Origin.

Tags:  @pchainho @antonroman ;)
